### PR TITLE
Fixed a bug in calc_discharge_rate that did not properly account for …

### DIFF
--- a/RaEDM_leakage_analysis.m
+++ b/RaEDM_leakage_analysis.m
@@ -1,9 +1,23 @@
-% function RaEDM_leakage_analysis(datafile,power_supply)
+function RaEDM_leakage_analysis(datafile,power_supply,avg)
 
-datafile = '2019-04-26-151416-hv-1.txt';
-power_supply = 4;
+% datafile = '2018-12-13-144501-hv-1.txt'; power_supply = 4;
 
-clearvars -except masterlist binsize datafile power_supply
+% histogram binning settings
+avg_binwidth = 5.0; % pA
+
+% avg_binwidth = 50.0; % 2/5/2019 data setting
+
+stdev_binwidth = 1.0; % pA (good for 200 nA LCM scale)
+
+% stdev_binwidth = 4.0; % pA (good for 2 uA LCM scale)
+
+% stdev_binwidth = 10.0; % 2/5/2019 data setting
+
+stdev_summed_binwidth = 0.25; % pA
+
+% stdev_summed_binwidth = 2.0;
+
+clearvars -except masterlist binsize datafile power_supply avg_binwidth stdev_binwidth stdev_summed_binwidth
 close all
 %clc
 
@@ -375,21 +389,6 @@ pressure_avg_pkpk = zeros(num_files,num_rows,1);
 % % 
 % % end
 
-% histogram binning settings
-avg_binwidth = 5.0; % pA
-
-% avg_binwidth = 50.0; % 2/5/2019 data setting
-
-stdev_binwidth = 1.0; % pA (good for 200 nA LCM scale)
-
-% stdev_binwidth = 4.0; % pA (good for 2 uA LCM scale)
-
-% stdev_binwidth = 10.0; % 2/5/2019 data setting
-
-stdev_summed_binwidth = 0.25; % pA
-
-% stdev_summed_binwidth = 2.0;
-
 if power_supply == 0
   
     disp('Using -30 kV Acopian power supply')
@@ -760,7 +759,7 @@ elseif power_supply == 1 || power_supply == 4
     
      lcm1_avg_scale = (-2)*1e4; %(pA, 200 nA scale)
     
-%     lcm1_avg_scale = (-2)*1e5; %(pA, 2 uA scale)
+%      lcm1_avg_scale = (-2)*1e5; %(pA, 2 uA scale)
     
     ohm_avg_scale = 1e3; % Mohm
     

--- a/calc_discharge_rate.m
+++ b/calc_discharge_rate.m
@@ -4,11 +4,11 @@ function [dph,dph_std,median_discharge_size,...
     discharge_stdevs,discharges_per_chunk,time_length_of_chunk,...
     official_sim_start_time,official_sim_end_time)
 
-% start_time = discharge_times(1,1);
-
 start_time = official_sim_start_time;
 
 end_time = official_sim_end_time;
+
+% fprintf('official EDMRS runtime = %.1f hr\n',(official_sim_end_time - official_sim_start_time)/60.0);
 
 % add an element that indicates to the algorithm when the simulation has
 % officially ended so that we can account for the time between the last
@@ -40,17 +40,7 @@ live_time = 0.0;
     
     median_discharge_size = [];
     overall_median_discharge_size = 0;
-    
-%     if length(discharge_times(1,:)) < 1
-%         
-%         dph = [0];
-%         overall_dph = 0;
-%         
-%         dph_std = [0];
-%         overall_dph_std = 0;
-%         
-%         median_discharge_size = [0];
-%         overall_median_discharge_size = 0;
+
         
     if length(discharge_times(1,:)) < 2
         
@@ -65,19 +55,6 @@ live_time = 0.0;
         median_discharge_size = zeros(1,num_hours);
         overall_median_discharge_size = zeros(1,num_hours);
         
-%     elseif length(discharge_times(1,:)) == 1
-%         
-%         dph = [1];
-%         overall_dph = 1;
-%         
-%         dph_std = [1];
-%         overall_dph_std = 1;
-%         
-%         median_discharge_size = [discharge_vals(1,1)];
-%         
-%         overall_median_discharge_size = discharge_vals(1,1);        
-        
-%     elseif length(discharge_times(1,:)) > 1
     else
         
         overall_dph = ...
@@ -100,53 +77,38 @@ live_time = 0.0;
     
         for i =1:length(discharge_times(1,:))
             
-%             fprintf('i=%d\n',i);
-%             fprintf('start time index = %d\n',start_time_index);
-
-            % time between this discharge and discharge from last dph value
-            
-            time_delta = discharge_times(1,i) - start_time;
-            
-%            live_time = live_time + time_length_of_chunk(discharge_times(2,i)); 
-
-            if i==start_time_index
-                
-%                 live_time = live_time + ...
-%                     sum(time_length_of_chunk(start_time_index:discharge_times(2,i)));
-                live_time = live_time + ...
-                    sum(time_length_of_chunk(discharge_times(2,i)));
-            
-            elseif discharge_times(2,i) ~= discharge_times(2,i-1)
-                    
-                    live_time = live_time + ...
-                        sum(time_length_of_chunk(discharge_times(2,i-1)+1:discharge_times(2,i)));
-                                    
-            end
-            
-%             fprintf('live time = %f\n',live_time);
-            
-%             time_since_last_hour = discharge_times(1,i) - first_discharge_time - 60.0*hour_number;
-            
-%             time_since_last_hour = discharge_times(1,i) - first_discharge_time + ...
-%                 leftover_time - 60.0*hour_number;
-            
             time_since_last_hour = discharge_times(1,i) + ...
-                leftover_time - 60.0*hour_number;
+                leftover_time - 60.0*hour_number; 
             
-%             fprintf('time since last hour = %f\n',time_since_last_hour);
+%             fprintf('hour number %d, i = %d, time since last hour = %.1f\n',...
+%                 hour_number,i,time_since_last_hour);
             
             % if time_since_last_hour > 0, than over an hour has elapsed
             % since the first discharge in this sequence of discharges, and
             % we compute a new discharge rate
             
-            if time_since_last_hour > 0.0 
+            if time_since_last_hour < 0.0
+                
+                % time between this discharge and discharge from last dph value
+
+                if i==start_time_index
+
+                    live_time = live_time + ...
+                        sum(time_length_of_chunk(discharge_times(2,i)));
+
+                elseif discharge_times(2,i) ~= discharge_times(2,i-1)
+
+                        live_time = live_time + ...
+                            sum(time_length_of_chunk(discharge_times(2,i-1)+1:discharge_times(2,i)));
+
+                end
+            
+            elseif time_since_last_hour > 0.0
                 
                 % if more than an hour passes between discharges, we need
                 % to record that zero discharges occurred
                 
-                 if time_since_last_hour > 60.0 
-                     
-%                      disp('more than an hour passed without a discharge, yay!');
+                 if time_since_last_hour > 60.0                     
                      
                      hours_between_discharge = floor(time_since_last_hour/60);
                      
@@ -154,94 +116,70 @@ live_time = 0.0;
                      
                      start_time = start_time + hours_between_discharge*60.;
                      
-                     avg_discharges_this_hour = ...
-                        length(find(discharge_vals(1,start_time_index:i-1)))*...
-                        60.0/(hours_between_discharge*live_time);
+                     % check if discharge occured, than 1++ hours passed
+                     % without discharges. In this case that first
+                     % discharge needs to be accounted for.
+                     
+                     if i - 1 > start_time_index
+                     
+                         avg_discharges_this_hour = ...
+                            length(find(discharge_vals(1,start_time_index:i-1)))*...
+                            60.0/(live_time);
 
-                     std_this_hour = sqrt(avg_discharges_this_hour);
+                         std_this_hour = sqrt(avg_discharges_this_hour);
 
-                     if isempty(find(discharge_vals(1,start_time_index:i-1),1))
+                         if isempty(find(discharge_vals(1,start_time_index:i-1),1))
 
-                         median_discharge_size_this_hour = 0.0;
+                             median_discharge_size_this_hour = 0.0;
 
+                         else
+
+                             [row, col, val] = find(discharge_vals(1,start_time_index:i-1));
+
+                             median_discharge_size_this_hour = median(val);
+
+                         end
+                         
                      else
-
-                         [row, col, val] = find(discharge_vals(1,start_time_index:i-1));
- 
-                         median_discharge_size_this_hour = median(val);
-
+                         
+                         avg_discharges_this_hour = 0.0;
+                         
+                         std_this_hour = 0.0;
+                         
+                         median_discharge_size_this_hour = 0.0;
+                     
                      end
                      
                      start_time_index = i;
                      
-                     dph = [dph ones(1,hours_between_discharge)*avg_discharges_this_hour];
-
-                        dph_std = [dph_std ones(1,hours_between_discharge)*std_this_hour];
-
-                        median_discharge_size = ...
-                            [median_discharge_size ones(1,hours_between_discharge)*median_discharge_size_this_hour];
-                    
-                     time_since_last_hour = time_since_last_hour - hours_between_discharge*60.0;
+%                      dph = [dph ones(1,hours_between_discharge)*avg_discharges_this_hour];
                      
-%                      fprintf('%d hour(s) between discharges. New time since last hour = %f\n',hours_between_discharge,time_since_last_hour);
+                     dph = [dph avg_discharges_this_hour zeros(1,hours_between_discharge-1)];
+
+%                      dph_std = [dph_std ones(1,hours_between_discharge)*std_this_hour];
                      
-%                 if time_since_last_hour > 60.0 && isempty(find(discharge_vals(1,start_index:i),1))
+                     dph_std = [dph_std std_this_hour zeros(1,hours_between_discharge-1)];
+
+%                      median_discharge_size = ...
+%                          [median_discharge_size ones(1,hours_between_discharge)*median_discharge_size_this_hour];
+                     
+                     median_discharge_size = ...
+                         [median_discharge_size median_discharge_size_this_hour zeros(1,hours_between_discharge-1)];
                     
-%                     while time_since_last_hour > 60.0
-%                         
-%                         
-%                         
-%                         time_since_last_hour = time_since_last_hour - 60.0;
-%                         
-%                         fprintf('subtracting hour from elapsed time. New time since last hour = %f\n',time_since_last_hour);
-%                    
-%                         
-%                         
-% %                         avg_discharges_this_hour = 0.0;
-% % 
-% %                         std_this_hour = sqrt(avg_discharges_this_hour);
-% 
-% %                         median_discharge_size_this_hour = 0.0;
-%                         
-%                         %%%
-% 
-%                         hour_number = hour_number+1;
-%                         
-%                         start_time = start_time + 60.0;
-%                         
-%                         if start_time_index < i-1
-%                             
-%                             start_time_index = start_time_index+1;
-%                             
-%                         end
-% 
-%                         dph = [dph avg_discharges_this_hour];
-% 
-%                         dph_std = [dph_std std_this_hour];
-% 
-%                         median_discharge_size = ...
-%                             [median_discharge_size median_discharge_size_this_hour];
-%                         
-%                         %%%
-% 
-%                         
-%                     end
-                    
-%                 end
+                     time_since_last_hour = time_since_last_hour - hours_between_discharge*60.0;                                          
+
+                % if discharges did occur in this hour...                
                 else
 
                     %discharges per hour
-
+                    
 %                     avg_discharges_this_hour = ...
-%                         length(discharge_times(1,start_time_index:i))*60.0/live_time;
+%                         length(find(discharge_vals(1,start_time_index:i)))*60.0/live_time;
                     
                     avg_discharges_this_hour = ...
-                        length(find(discharge_vals(1,start_time_index:i)))*60.0/live_time;
+                        length(find(discharge_vals(1,start_time_index:i-1)))*60.0/live_time;
 
                     std_this_hour = sqrt(avg_discharges_this_hour);
-
-%                     median_discharge_size_this_hour = ...
-%                         median(discharge_vals(1,start_time_index:i));
                     
 
                     if isempty(find(discharge_vals(1,start_time_index:i),1))
@@ -255,41 +193,25 @@ live_time = 0.0;
                         median_discharge_size_this_hour = median(val);
                         
                     end
-
-%                     dph = [dph avg_discharges_this_hour];
-% 
-%                     dph_std = [dph_std std_this_hour];
-% 
-%                     median_discharge_size = ...
-%                         [median_discharge_size median_discharge_size_this_hour];
                 
                 end
 
                 % now redefine start_time and start_time_index so that we can
                 % look for the avg. # of discharges for the next hour.
-                
-                % Break loop if we're at the last point                                
-                
-%                 if i == length(discharge_times(1,:))
-%                     
-% %                     start_time = discharge_times(1,i);
-% 
-% %                     start_time_index = i;
-%                     
-%                     break;
                     
                 if i ~= length(discharge_times(1,:))
                     
-%                     start_time = discharge_times(1,i);
+%                     start_time = discharge_times(1,i) + time_since_last_hour;
                     
-                    start_time = discharge_times(1,i) + time_since_last_hour;
+                    start_time = official_sim_start_time + 60.*hour_number;
 
-%                     start_time_index = i;
-                    start_time_index = i+1;
+%                     start_time_index = i+1;
+                    
+                    start_time_index = i;
                     
                     hour_number = hour_number+1;
                     
-                    leftover_time = time_since_last_hour;
+%                     leftover_time = 0;
                     
                     live_time = 0.0;
                     
@@ -304,32 +226,99 @@ live_time = 0.0;
 
             end
 
-        end
+        end                      
         
-              
+        if official_sim_end_time > discharge_times(1,end)
+                
+            time_since_last_hour = time_since_last_hour + (official_sim_end_time - discharge_times(1,end));
+
+        end
         
         % if we don't get a full last hour, we can extrapolate the last
         % dph
         
-        time_delta = discharge_times(1,end) - start_time;
+        %%%
+        
+        if time_since_last_hour > 60.0                     
+                     
+             hours_between_discharge = floor(time_since_last_hour/60);
+
+             hour_number = hour_number + hours_between_discharge;
+
+             start_time = start_time + hours_between_discharge*60.;
+
+             % check if discharge occured, than 1++ hours passed
+             % without discharges. In this case that first
+             % discharge needs to be accounted for.
+
+             if i - 1 > start_time_index
+
+                 avg_discharges_this_hour = ...
+                    length(find(discharge_vals(1,start_time_index:i-1)))*...
+                    60.0/(live_time);
+
+                 std_this_hour = sqrt(avg_discharges_this_hour);
+
+                 if isempty(find(discharge_vals(1,start_time_index:i-1),1))
+
+                     median_discharge_size_this_hour = 0.0;
+
+                 else
+
+                     [row, col, val] = find(discharge_vals(1,start_time_index:i-1));
+
+                     median_discharge_size_this_hour = median(val);
+
+                 end
+
+             else
+
+                 avg_discharges_this_hour = 0.0;
+
+                 std_this_hour = 0.0;
+
+                 median_discharge_size_this_hour = 0.0;
+
+             end
+
+             start_time_index = i;
+
+%                      dph = [dph ones(1,hours_between_discharge)*avg_discharges_this_hour];
+
+             dph = [dph avg_discharges_this_hour zeros(1,hours_between_discharge-1)];
+
+%                      dph_std = [dph_std ones(1,hours_between_discharge)*std_this_hour];
+
+             dph_std = [dph_std std_this_hour zeros(1,hours_between_discharge-1)];
+
+%                      median_discharge_size = ...
+%                          [median_discharge_size ones(1,hours_between_discharge)*median_discharge_size_this_hour];
+
+             median_discharge_size = ...
+                 [median_discharge_size median_discharge_size_this_hour zeros(1,hours_between_discharge-1)];
+
+             time_since_last_hour = time_since_last_hour - hours_between_discharge*60.0;                                          
+
+        end
+        
+        %%%
             
-%         if time_since_last_hour < 0.0 && start_time_index ~= length(discharge_times(1,:)) && ...
-%                 time_delta > 8.0
+%         if time_since_last_hour >= 30.0
+        
+        if time_since_last_hour >= -30.0
             
-%         if time_since_last_hour < 0.0  && time_delta > 15.0
-        if time_since_last_hour >= 30.0
+%             extrapolate_last_hour = round(time_since_last_hour/60.);
+
+            fraction_last_hour = abs((60.-time_since_last_hour)/60.);
+                        
+%             avg_discharges_this_hour = ...
+%                 length(find(discharge_vals(1,start_time_index:end)))*60/...
+%                 ((extrapolate_last_hour+1)*live_time);
             
-            extrapolate_last_hour = round(time_since_last_hour/60.);
-                       
-%             fprintf('extrapolated %d hours\n',extrapolate_last_hour);
-%             fprintf('live time = %f\n',live_time);
- 
             avg_discharges_this_hour = ...
                 length(find(discharge_vals(1,start_time_index:end)))*60/...
-                ((extrapolate_last_hour+1)*live_time);
-            
-%             fprintf('avg discharges this hour = %f\n',avg_discharges_this_hour);
-            
+                ((fraction_last_hour)*live_time);
+                        
             std_this_hour = sqrt(avg_discharges_this_hour);
 
             if isempty(find(discharge_vals(1,start_time_index:end),1))
@@ -344,17 +333,24 @@ live_time = 0.0;
 
             end     
                 
+%             median_discharge_size = ...
+%                 [median_discharge_size ones(1,1+fraction_last_hour)*...
+%                 median_discharge_size_this_hour];
+%             
+%             dph = [dph ones(1,fraction_last_hour+1)*avg_discharges_this_hour];
+%             
+%             dph_std = [dph_std ones(1,fraction_last_hour+1)*std_this_hour];
+            
             median_discharge_size = ...
-                [median_discharge_size ones(1,1+extrapolate_last_hour)*...
-                median_discharge_size_this_hour];
+                [median_discharge_size median_discharge_size_this_hour];
             
-            dph = [dph ones(1,extrapolate_last_hour+1)*avg_discharges_this_hour];
+            dph = [dph avg_discharges_this_hour];
             
-            dph_std = [dph_std ones(1,extrapolate_last_hour+1)*std_this_hour];
-            
-%         elseif time_since_last_hour < 0.0 && start_time_index ~= length(discharge_times(1,:)) && ...
-%                 time_delta < 8.0
-            
+            dph_std = [dph_std std_this_hour];
+
+        % if there is less than thirty minutes of unaccounted-for discharge
+        % time, just roll it into the last point and re-average that 
+        % discharge rate
         else
           
 
@@ -389,26 +385,10 @@ live_time = 0.0;
                     end
                     
             end
-            
-%             dph(end) = (dph(end) + avg_discharges_this_hour)/2.0;
-%             
-%             dph_std(end) = sqrt((dph_std(end))^2+ (std_this_hour)^2);
-%             
-%             median_discharge_size(end) = median_discharge_size_this_hour;
 
             if length(dph) > 0
 
-%                 fprintf('dph(end) = %f\n',dph(end));
-% 
-%                 fprintf('live_time = %f\n',live_time);
-% 
-%                 fprintf('avg_discharges_this_hour = %f\n',avg_discharges_this_hour);            
-
                 dph(end) = (dph(end) + (live_time/60.0)*avg_discharges_this_hour)/(1.0+live_time/60.0);
-
-%                 fprintf('dph(end) after extrapolation = %f\n',dph(end));
-
-    %             dph_std(end) = sqrt(dph_std(end));
 
                 dph_std(end) = sqrt(dph(end));
 

--- a/sort_state.m
+++ b/sort_state.m
@@ -615,7 +615,7 @@ function [lcm1_avg_trash_raw,lcm1_weight_avg_trash_raw,...
                 %trash_chunk_begin = j-1;
                 trash_chunk_begin = j;
                 
-                fprintf('found first trash chunk! = %d \n',j);
+%                 fprintf('found first trash chunk! = %d \n',j);
                 
                 break;
                 
@@ -638,7 +638,7 @@ function [lcm1_avg_trash_raw,lcm1_weight_avg_trash_raw,...
                 
                 trash_chunk_end = j;
                 
-                fprintf('found last trash chunk! = %d \n',j);
+%                 fprintf('found last trash chunk! = %d \n',j);
                 
                 break;                                
                 
@@ -681,8 +681,8 @@ function [lcm1_avg_trash_raw,lcm1_weight_avg_trash_raw,...
         
         num_trash_chunks(i) = trash_chunk_end - trash_chunk_begin + 1; 
         
-        fprintf('num_trash_chunks = %d - %d + 1 = %d\n',trash_chunk_end,...
-            trash_chunk_begin,num_trash_chunks);
+%         fprintf('num_trash_chunks = %d - %d + 1 = %d\n',trash_chunk_end,...
+%             trash_chunk_begin,num_trash_chunks);
         
         
 %         for j =trash_chunk_begin:num_trash_chunks(i)+1


### PR DESCRIPTION
…the last data point in all cases. It would be good to rerun the Nb56 data to ensure that this did not have an effect on those files. Still need to implement some sort of fix for when the chunks are too noisy. Idea: If minimizing algorithm has issues, simply revert to original guesses.