### PR TITLE
Redid analysis of Nb78 electrodes. Many minor errors manifested in th…

### DIFF
--- a/RaEDM_leakage_analysis.m
+++ b/RaEDM_leakage_analysis.m
@@ -1,6 +1,6 @@
 % function RaEDM_leakage_analysis(datafile,power_supply)
 
-datafile = '2019-07-18-140330-hv-1.txt'; power_supply = 4;
+datafile = '2018-11-14-163806-hv-1.txt'; power_supply = 4;
 
 % histogram binning settings
 avg_binwidth = 5.0; % pA
@@ -642,58 +642,109 @@ elseif power_supply == 4
            end
            
         end
-
-        for j =1:numpoints(i)
+        
+        time_raw(i,1:numpoints) = data(i,1:numpoints,1);
+        
+        vmon_avg_raw_mag(i,1:numpoints) = data(i,1:numpoints,3);
            
-            time_raw(i,j) = data(i,j,1);
+            imon_avg_raw(i,1:numpoints) = data(i,1:numpoints,4);
            
-            vmon_avg_raw_mag(i,j) = data(i,j,3);
+            lcm1_avg_raw(i,1:numpoints) = data(i,1:numpoints,5);
            
-            imon_avg_raw(i,j) = data(i,j,4);
-           
-            lcm1_avg_raw(i,j) = data(i,j,5);
-           
-            pressure_avg_raw(i,j) = data(i,j,7);
+            pressure_avg_raw(i,1:numpoints) = data(i,1:numpoints,7);
           
             % ~20 mV Low (positive), ~ 3.4 V high (negative)
-            polarity_avg_raw(i,j) = data(i,j,8); 
+            polarity_avg_raw(i,1:numpoints) = data(i,1:numpoints,8); 
          
             %don't think reduced sqrt is true for fast data
-            vmon_avg_stdev_raw(i,j) = data(i,j,11)/sqrt(sample_size_setting); 
+            vmon_avg_stdev_raw(i,1:numpoints) = data(i,1:numpoints,11)/sqrt(sample_size_setting); 
         
-            vmon_weight_raw(i,j) = abs((vmon_avg_stdev_raw(i,j))^(-2));
+            vmon_weight_raw(i,1:numpoints) = abs((vmon_avg_stdev_raw(i,1:numpoints)).^(-2));
             
-            imon_avg_stdev_raw(i,j) = data(i,j,12)/sqrt(sample_size_setting);
+            imon_avg_stdev_raw(i,1:numpoints) = data(i,1:numpoints,12)/sqrt(sample_size_setting);
             
-            imon_weight_raw(i,j) = abs((imon_avg_stdev_raw(i,j))^(-2));
+            imon_weight_raw(i,1:numpoints) = abs((imon_avg_stdev_raw(i,1:numpoints)).^(-2));
             
-            lcm1_avg_stdev_raw(i,j) = data(i,j,13)/sqrt(sample_size_setting);
+            lcm1_avg_stdev_raw(i,1:numpoints) = data(i,1:numpoints,13)/sqrt(sample_size_setting);
             
-            pressure_avg_stdev_raw(i,j) = data(i,j,15);
+            pressure_avg_stdev_raw(i,1:numpoints) = data(i,1:numpoints,15);
+            
+            if length(data(i,1,:)) > 18
+            
+                vmon_avg_pkpk_raw(i,1:numpoints) = data(i,1:numpoints,19)/sqrt(sample_size_setting); 
+            
+                imon_avg_pkpk_raw(i,1:numpoints) = data(i,1:numpoints,20)/sqrt(sample_size_setting);            
+            
+                lcm1_avg_pkpk_raw(i,1:numpoints) = data(i,1:numpoints,21)/sqrt(sample_size_setting);
+            
+                pressure_avg_pkpk_raw(i,1:numpoints) = data(i,1:numpoints,23);
+            
+            end
             
             
-            vmon_avg_pkpk_raw(i,j) = data(i,j,19)/sqrt(sample_size_setting); 
+            lcm1_weight_raw(i,1:numpoints) = abs(1./(lcm1_avg_stdev_raw(i,1:numpoints).^2));
             
-            imon_avg_pkpk_raw(i,j) = data(i,j,20)/sqrt(sample_size_setting);            
+            lcm1_avg_wt_raw(i,1:numpoints) = lcm1_avg_raw(i,1:numpoints).*lcm1_weight_raw(i,1:numpoints);
             
-            lcm1_avg_pkpk_raw(i,j) = data(i,j,21)/sqrt(sample_size_setting);
+            ohm_avg_raw(i,1:numpoints) = vmon_avg(i,1:numpoints)./imon_avg(i,1:numpoints)*1e3; % Mohm
             
-            pressure_avg_pkpk_raw(i,j) = data(i,j,23);
+            vmon_avg_wt_raw_mag(i,1:numpoints) = vmon_avg_raw_mag(i,1:numpoints).*vmon_weight_raw(i,1:numpoints);
             
+            imon_avg_wt_raw(i,1:numpoints) = imon_avg_raw(i,1:numpoints).*imon_weight_raw(i,1:numpoints);
             
-            lcm1_weight_raw(i,j) = abs(1/(lcm1_avg_stdev_raw(i,j)^2));
-            
-            lcm1_avg_wt_raw(i,j) = lcm1_avg_raw(i,j)*lcm1_weight_raw(i,j);
-            
-            ohm_avg_raw(i,j) = vmon_avg(i,j)/imon_avg(i,j)*1e3; % Mohm
-            
-            vmon_avg_wt_raw_mag(i,j) = vmon_avg_raw_mag(i,j)*vmon_weight_raw(i,j);
-            
-            imon_avg_wt_raw(i,j) = imon_avg_raw(i,j)*imon_weight_raw(i,j);
-            
-            field_avg_raw(i,j) = vmon_avg_raw_mag(i,j)/gap_size(i); % (raw vmon / cm)
-            
-        end
+            field_avg_raw(i,1:numpoints) = vmon_avg_raw_mag(i,1:numpoints)/gap_size(i); % (raw vmon / cm)
+
+%         for j =1:numpoints(i)
+%            
+%             time_raw(i,j) = data(i,j,1);
+%            
+%             vmon_avg_raw_mag(i,j) = data(i,j,3);
+%            
+%             imon_avg_raw(i,j) = data(i,j,4);
+%            
+%             lcm1_avg_raw(i,j) = data(i,j,5);
+%            
+%             pressure_avg_raw(i,j) = data(i,j,7);
+%           
+%             % ~20 mV Low (positive), ~ 3.4 V high (negative)
+%             polarity_avg_raw(i,j) = data(i,j,8); 
+%          
+%             %don't think reduced sqrt is true for fast data
+%             vmon_avg_stdev_raw(i,j) = data(i,j,11)/sqrt(sample_size_setting); 
+%         
+%             vmon_weight_raw(i,j) = abs((vmon_avg_stdev_raw(i,j))^(-2));
+%             
+%             imon_avg_stdev_raw(i,j) = data(i,j,12)/sqrt(sample_size_setting);
+%             
+%             imon_weight_raw(i,j) = abs((imon_avg_stdev_raw(i,j))^(-2));
+%             
+%             lcm1_avg_stdev_raw(i,j) = data(i,j,13)/sqrt(sample_size_setting);
+%             
+%             pressure_avg_stdev_raw(i,j) = data(i,j,15);
+%             
+%             
+%             vmon_avg_pkpk_raw(i,j) = data(i,j,19)/sqrt(sample_size_setting); 
+%             
+%             imon_avg_pkpk_raw(i,j) = data(i,j,20)/sqrt(sample_size_setting);            
+%             
+%             lcm1_avg_pkpk_raw(i,j) = data(i,j,21)/sqrt(sample_size_setting);
+%             
+%             pressure_avg_pkpk_raw(i,j) = data(i,j,23);
+%             
+%             
+%             lcm1_weight_raw(i,j) = abs(1/(lcm1_avg_stdev_raw(i,j)^2));
+%             
+%             lcm1_avg_wt_raw(i,j) = lcm1_avg_raw(i,j)*lcm1_weight_raw(i,j);
+%             
+%             ohm_avg_raw(i,j) = vmon_avg(i,j)/imon_avg(i,j)*1e3; % Mohm
+%             
+%             vmon_avg_wt_raw_mag(i,j) = vmon_avg_raw_mag(i,j)*vmon_weight_raw(i,j);
+%             
+%             imon_avg_wt_raw(i,j) = imon_avg_raw(i,j)*imon_weight_raw(i,j);
+%             
+%             field_avg_raw(i,j) = vmon_avg_raw_mag(i,j)/gap_size(i); % (raw vmon / cm)
+%             
+%         end
         
     time(i,:) = (time_raw(i,:) - time_raw(i,1))/60.0; %min
     

--- a/batch_process_hv_sim_nb78.m
+++ b/batch_process_hv_sim_nb78.m
@@ -1,0 +1,24 @@
+clearvars -except masterlist binsize
+close all
+
+RaEDM_leakage_analysis('2018-10-24-164446-hv-1.txt',4); 
+ 
+RaEDM_leakage_analysis('2018-10-25-153857-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-10-26-142009-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-10-26-162012-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-10-31-162157-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-11-01-174934-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-11-02-140707-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-11-02-162509-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-11-07-161056-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-11-08-162446-hv-1.txt',4); 
+
+RaEDM_leakage_analysis('2018-11-14-163806-hv-1.txt',4); 

--- a/calc_discharge_rate.m
+++ b/calc_discharge_rate.m
@@ -4,37 +4,39 @@ function [dph,dph_std,median_discharge_size,...
     discharge_stdevs,discharges_per_chunk,time_length_of_chunk,...
     official_sim_start_time,official_sim_end_time,title_string,plotname,save_figs,savepath)
 
-xlabel_string = 'leakage current (pA)';
-ylabel_string = 'frequency';
-%text box assignments
-inside_plot = [0.1375 0.73 0.5 0.19]; % edges: x y width height
+    
+
+    xlabel_string = 'leakage current (pA)';
+    ylabel_string = 'frequency';
+    %text box assignments
+    inside_plot = [0.1375 0.73 0.5 0.19]; % edges: x y width height
 
 
-start_time = official_sim_start_time;
+    start_time = official_sim_start_time;
 
-end_time = official_sim_end_time;
+    end_time = official_sim_end_time;
 
-% fprintf('official EDMRS runtime = %.1f hr\n',(official_sim_end_time - official_sim_start_time)/60.0);
+    % fprintf('official EDMRS runtime = %.1f hr\n',(official_sim_end_time - official_sim_start_time)/60.0);
 
-% add an element that indicates to the algorithm when the simulation has
-% officially ended so that we can account for the time between the last
-% discharge and the actual end of the simulation
+    % add an element that indicates to the algorithm when the simulation has
+    % officially ended so that we can account for the time between the last
+    % discharge and the actual end of the simulation
 
-discharge_times = [discharge_times [end_time ; length(time_length_of_chunk)] ];
+    discharge_times = [discharge_times [end_time ; length(time_length_of_chunk)] ];
 
-discharge_vals = [discharge_vals [0 ; length(time_length_of_chunk)] ];
+    discharge_vals = [discharge_vals [0 ; length(time_length_of_chunk)] ];
 
-discharge_stdevs = [discharge_stdevs [ 0 ; length(time_length_of_chunk)] ];
+    discharge_stdevs = [discharge_stdevs [ 0 ; length(time_length_of_chunk)] ];
 
-first_discharge_time = discharge_times(1,1);
+    first_discharge_time = discharge_times(1,1);
 
-% leftover_time = 0.0;
+    % leftover_time = 0.0;
 
-leftover_time = -official_sim_start_time;
+    leftover_time = -official_sim_start_time;
 
-hour_number = 1;
+    hour_number = 1;
 
-live_time = 0.0;
+    live_time = 0.0;
 
     start_time_index = 1;
     
@@ -46,11 +48,19 @@ live_time = 0.0;
     
     median_discharge_size = [];
     overall_median_discharge_size = 0;
-
+    
+    vals_list = [];
+    vals_per_hour = [];
+    
+    live_time_list = [];
+    
+    
         
     if length(discharge_times(1,:)) < 2
         
-        num_hours = ceil((end_time - start_time)/60.0);
+        
+        
+        num_hours = round((end_time - start_time)/60.0);
     
         dph = zeros(1,num_hours);
         overall_dph = zeros(1,num_hours);
@@ -69,25 +79,26 @@ live_time = 0.0;
                 
         overall_dph_std = sqrt(overall_dph);
         
+        
+        
         if isempty(find(discharge_vals(1,start_time_index:end),1))
             
             overall_median_discharge_size = 0.0;
             
         else
             
-            [row, col, val] = find(discharge_vals(1,start_time_index:end));
+            [row, col, vals] = find(discharge_vals(1,start_time_index:end));
 
-            overall_median_discharge_size = median(val);
+            overall_median_discharge_size = median(vals);
             
         end
+        
+        
     
         for i =1:length(discharge_times(1,:))
             
             time_since_last_hour = discharge_times(1,i) + ...
                 leftover_time - 60.0*hour_number; 
-            
-%             fprintf('hour number %d, i = %d, time since last hour = %.1f\n',...
-%                 hour_number,i,time_since_last_hour);
             
             % if time_since_last_hour > 0, than over an hour has elapsed
             % since the first discharge in this sequence of discharges, and
@@ -97,19 +108,25 @@ live_time = 0.0;
                 
                 % time between this discharge and discharge from last dph value
 
-                if i==start_time_index
+                if i==start_time_index % if it's the first discharge
 
                     live_time = live_time + ...
                         sum(time_length_of_chunk(discharge_times(2,i)));
 
                 elseif discharge_times(2,i) ~= discharge_times(2,i-1)
 
-                        live_time = live_time + ...
-                            sum(time_length_of_chunk(discharge_times(2,i-1)+1:discharge_times(2,i)));
+                    live_time = live_time + ...
+                        sum(time_length_of_chunk(discharge_times(2,i-1)+1:discharge_times(2,i)));
 
                 end
             
             elseif time_since_last_hour > 0.0
+                
+                if length(live_time_list) < length(time_length_of_chunk)  
+                    
+                    live_time_list = [live_time_list live_time];
+                    
+                end
                 
                 % if more than an hour passes between discharges, we need
                 % to record that zero discharges occurred
@@ -122,7 +139,7 @@ live_time = 0.0;
                      
                      start_time = start_time + hours_between_discharge*60.;
                      
-                     % check if discharge occured, than 1++ hours passed
+                     % check if discharge occured, then if 1++ hours passed
                      % without discharges. In this case that first
                      % discharge needs to be accounted for.
                      
@@ -130,6 +147,13 @@ live_time = 0.0;
                      
                          [row,col,vals] = find(discharge_vals(1,start_time_index:i-1));
                          
+%                          vals_list = [vals_list vals];
+%                          
+%                          if length(vals_per_hour) < length(time_length_of_chunk)
+% 
+%                             vals_per_hour = [vals_per_hour length(vals)];
+% 
+%                          end
                          
 %                          avg_discharges_this_hour = length(vals)*60.0/(live_time);
                          avg_discharges_this_hour = ceil(length(vals)*60.0/(live_time));
@@ -137,14 +161,14 @@ live_time = 0.0;
 %                          std_this_hour = sqrt(avg_discharges_this_hour);
                          std_this_hour = ceil(sqrt(length(vals))*60.0/live_time);
                          
-                         if save_figs == 1
-                             
-                             save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
-                             
-                             plot_discharge_hist(vals,title_string,hour_number,...
-                                 save_file_path,xlabel_string,ylabel_string);
- 
-                         end
+%                          if save_figs == 1
+%                              
+%                              save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
+%                              
+%                              plot_discharge_hist(vals,title_string,hour_number,...
+%                                  save_file_path,xlabel_string,ylabel_string);
+%  
+%                          end
 
                          if isempty(find(discharge_vals(1,start_time_index:i-1),1))
 
@@ -152,9 +176,17 @@ live_time = 0.0;
 
                          else
 
-                             [row, col, val] = find(discharge_vals(1,start_time_index:i-1));
+                             [row, col, vals] = find(discharge_vals(1,start_time_index:i-1));
+                             
+%                              vals_list = [vals_list vals];
+%                          
+%                              if length(vals_per_hour) < length(time_length_of_chunk)
+%                                  
+%                                 vals_per_hour = [vals_per_hour length(vals)];
+%                                 
+%                              end
 
-                             median_discharge_size_this_hour = median(val);
+                             median_discharge_size_this_hour = median(vals);
 
                          end
                          
@@ -167,24 +199,74 @@ live_time = 0.0;
                          std_this_hour = 0.0;
                          
                          median_discharge_size_this_hour = 0.0;
+                         
+                         % no discharge occured, so vals is empty vector
+                         vals = [];
                      
+                     end
+                     
+                     %%%
+                     
+                     vals_list = [vals_list vals];
+                         
+                     if length(vals_per_hour) + hours_between_discharge -1 < length(time_length_of_chunk)
+
+                        vals_per_hour = [vals_per_hour zeros(1,hours_between_discharge - 1) length(vals)];
+                        
+                     elseif length(vals_per_hour) < length(time_length_of_chunk)
+                         
+                         vals_per_hour = [vals_per_hour length(vals)];
+                         
+                     elseif length(vals_per_hour) > 0
+                         
+                         vals_per_hour(end) = vals_per_hour(end) + length(vals);
+
                      end
                      
                      start_time_index = i;
                      
-%                      dph = [dph ones(1,hours_between_discharge)*avg_discharges_this_hour];
+                     % only build dph if there multiple chunks spanning
+                     % hours. A chunk only lasts ~ a minute. Sometimes we
+                     % want to look at all the chunks summed together. In
+                     % this case we only want one dph value.
+                     if length(dph) + hours_between_discharge-1 < length(time_length_of_chunk)  
                      
-                     dph = [dph avg_discharges_this_hour zeros(1,hours_between_discharge-1)];
+%                          dph = [dph avg_discharges_this_hour zeros(1,hours_between_discharge-1)];
+% 
+%                          dph_std = [dph_std std_this_hour zeros(1,hours_between_discharge-1)];
+%                          
+%                          median_discharge_size = ...
+%                              [median_discharge_size median_discharge_size_this_hour 
+%                              zeros(1,hours_between_discharge-1)];
+                         
+                         dph = [dph zeros(1,hours_between_discharge-1) avg_discharges_this_hour];
 
-%                      dph_std = [dph_std ones(1,hours_between_discharge)*std_this_hour];
-                     
-                     dph_std = [dph_std std_this_hour zeros(1,hours_between_discharge-1)];
+                         dph_std = [dph_std zeros(1,hours_between_discharge-1) std_this_hour];
+                         
+                         median_discharge_size = ...
+                             [median_discharge_size zeros(1,hours_between_discharge-1) 
+                             median_discharge_size_this_hour];
+                         
+                     elseif length(dph) < length(time_length_of_chunk)
+                         
+                         dph = [dph avg_discharges_this_hour];
 
-%                      median_discharge_size = ...
-%                          [median_discharge_size ones(1,hours_between_discharge)*median_discharge_size_this_hour];
+                         dph_std = [dph_std std_this_hour];
+                         
+                         median_discharge_size = ...
+                             [median_discharge_size 
+                             median_discharge_size_this_hour];
+                         
+                     elseif length(vals_per_hour) > 0
+                         
+                         dph(end) = mean(dph(end) + avg_discharges_this_hour);
+                         
+                         dph_std(end) = mean(dph_std(end)+std_this_hour);
+                         
+                         median_discharge_size(end) = mean(median_discharge_size(end)+...
+                             median_discharge_size_this_hour);
                      
-                     median_discharge_size = ...
-                         [median_discharge_size median_discharge_size_this_hour zeros(1,hours_between_discharge-1)];
+                     end
                     
                      time_since_last_hour = time_since_last_hour - hours_between_discharge*60.0;                                          
 
@@ -195,6 +277,15 @@ live_time = 0.0;
                     
                     [row,col,vals] = find(discharge_vals(1,start_time_index:i-1));
                     
+                    vals_list = [vals_list vals];
+                    
+                         
+                    if length(vals_per_hour) < length(time_length_of_chunk)
+
+                       vals_per_hour = [vals_per_hour length(vals)];
+
+                    end
+                    
 %                     avg_discharges_this_hour = ...
 %                         length(vals)*60.0/live_time;
                     
@@ -204,14 +295,14 @@ live_time = 0.0;
 %                     std_this_hour = sqrt(avg_discharges_this_hour);
                     std_this_hour = ceil(sqrt(length(vals))*60.0/live_time);
 
-                    if save_figs == 1
-                        
-                        save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
-                        
-                        plot_discharge_hist(vals,...
-                            title_string,hour_number,save_file_path,xlabel_string,ylabel_string);
-                        
-                     end
+%                     if save_figs == 1
+%                         
+%                         save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
+%                         
+%                         plot_discharge_hist(vals,...
+%                             title_string,hour_number,save_file_path,xlabel_string,ylabel_string);
+%                         
+%                      end
                     
 
                     if isempty(find(discharge_vals(1,start_time_index:i),1))
@@ -220,9 +311,9 @@ live_time = 0.0;
                         
                     else
                         
-                        [row, col, val] = find(discharge_vals(1,start_time_index:i));
+                        [row, col, vals] = find(discharge_vals(1,start_time_index:i));
                        
-                        median_discharge_size_this_hour = median(val);
+                        median_discharge_size_this_hour = median(vals);
                         
                     end
                 
@@ -247,16 +338,21 @@ live_time = 0.0;
                     
                     live_time = 0.0;
                     
-                    dph = [dph avg_discharges_this_hour];
+                    if length(dph) < length(time_length_of_chunk)  
+                    
+                        dph = [dph avg_discharges_this_hour];
 
-                    dph_std = [dph_std std_this_hour];
+                        dph_std = [dph_std std_this_hour];
 
-                    median_discharge_size = ...
-                        [median_discharge_size median_discharge_size_this_hour];
+                        median_discharge_size = ...
+                            [median_discharge_size median_discharge_size_this_hour];
+                    
+                    end
                     
                 end                                
 
             end
+            
 
         end                      
         
@@ -279,7 +375,7 @@ live_time = 0.0;
 
              start_time = start_time + hours_between_discharge*60.;
 
-             % check if discharge occured, than 1++ hours passed
+             % check if discharge occured, then if 1++ hours passed
              % without discharges. In this case that first
              % discharge needs to be accounted for.
 
@@ -287,24 +383,27 @@ live_time = 0.0;
 
                  [row,col,vals] = find(discharge_vals(1,start_time_index:i-1));
                  
-%                  avg_discharges_this_hour = ...
-%                     length(vals)*60.0/(live_time);
-% 
-%                  std_this_hour = sqrt(avg_discharges_this_hour);
+                 vals_list = [vals_list vals];
+                         
+                 if length(vals_per_hour) < length(time_length_of_chunk)
+
+                    vals_per_hour = [vals_per_hour length(vals)];
+
+                 end
                  
                  avg_discharges_this_hour = ...
                     ceil(length(vals)*60.0/(live_time));
 
                  std_this_hour = ceil(sqrt(length(vals))*60.0/live_time);
 
-                 if save_figs == 1
-                     
-                     save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
-                  
-                     plot_discharge_hist(vals,...
-                            title_string,hour_number,save_file_path,xlabel_string,ylabel_string)
-                        
-                 end
+%                  if save_figs == 1
+%                      
+%                      save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
+%                   
+%                      plot_discharge_hist(vals,...
+%                             title_string,hour_number,save_file_path,xlabel_string,ylabel_string)
+%                         
+%                  end
 
                  if isempty(find(discharge_vals(1,start_time_index:i-1),1))
 
@@ -312,9 +411,9 @@ live_time = 0.0;
 
                  else
 
-                     [row, col, val] = find(discharge_vals(1,start_time_index:i-1));
+                     [row, col, vals] = find(discharge_vals(1,start_time_index:i-1));
 
-                     median_discharge_size_this_hour = median(val);
+                     median_discharge_size_this_hour = median(vals);
 
                  end
 
@@ -330,21 +429,21 @@ live_time = 0.0;
 
              start_time_index = i;
 
-%                      dph = [dph ones(1,hours_between_discharge)*avg_discharges_this_hour];
+             if length(dph) < length(time_length_of_chunk)  
+                 
+                 dph = [dph avg_discharges_this_hour zeros(1,hours_between_discharge-1)];
 
-             dph = [dph avg_discharges_this_hour zeros(1,hours_between_discharge-1)];
+                 dph_std = [dph_std std_this_hour zeros(1,hours_between_discharge-1)];
 
-%                      dph_std = [dph_std ones(1,hours_between_discharge)*std_this_hour];
+                 median_discharge_size = ...
+                     [median_discharge_size median_discharge_size_this_hour ...
+                     zeros(1,hours_between_discharge-1)];
 
-             dph_std = [dph_std std_this_hour zeros(1,hours_between_discharge-1)];
-
-%                      median_discharge_size = ...
-%                          [median_discharge_size ones(1,hours_between_discharge)*median_discharge_size_this_hour];
-
-             median_discharge_size = ...
-                 [median_discharge_size median_discharge_size_this_hour zeros(1,hours_between_discharge-1)];
-
-             time_since_last_hour = time_since_last_hour - hours_between_discharge*60.0;                                          
+             end
+             
+             time_since_last_hour = time_since_last_hour - hours_between_discharge*60.0;
+             
+             
 
         end
         
@@ -354,26 +453,40 @@ live_time = 0.0;
 
             fraction_last_hour = abs((60.-time_since_last_hour)/60.);
             
+            % scale the live time to what it would have been if we went for
+            % a complete last hour
+            live_time = live_time/fraction_last_hour;
+            
+            if length(live_time_list) < length(time_length_of_chunk)  
+            
+                live_time_list = [live_time_list live_time];
+                
+            end
+            
             [row,col,vals] = find(discharge_vals(1,start_time_index:end));
             
-%             avg_discharges_this_hour = ...
-%                 length(vals)*60.0/((fraction_last_hour)*live_time);
-%                         
-%             std_this_hour = sqrt(avg_discharges_this_hour);
+            vals_list = [vals_list vals];
+            
+                         
+            if length(vals_per_hour) < length(time_length_of_chunk)
+
+                vals_per_hour = [vals_per_hour length(vals)];
+
+            end
             
             avg_discharges_this_hour = ...
-                ceil(length(vals)*60.0/((fraction_last_hour)*live_time));
+                ceil(length(vals)*60.0/live_time);
                         
-            std_this_hour = ceil(sqrt(length(vals))*60.0/((fraction_last_hour)*live_time));
+            std_this_hour = ceil(sqrt(length(vals))*60.0/live_time);
             
-            if save_figs == 1
-                
-                save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
-                
-                plot_discharge_hist(vals,...
-                            title_string,hour_number,save_file_path,xlabel_string,ylabel_string)
-                        
-             end
+%             if save_figs == 1
+%                 
+%                 save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
+%                 
+%                 plot_discharge_hist(vals,...
+%                             title_string,hour_number,save_file_path,xlabel_string,ylabel_string)
+%                         
+%              end
 
             if isempty(find(discharge_vals(1,start_time_index:end),1))
 
@@ -381,18 +494,22 @@ live_time = 0.0;
 
             else
 
-                [row, col, val] = find(discharge_vals(1,start_time_index:end));
+                [row, col, vals] = find(discharge_vals(1,start_time_index:end));
 
-                median_discharge_size_this_hour = median(val);
+                median_discharge_size_this_hour = median(vals);
 
             end     
-                            
-            median_discharge_size = ...
-                [median_discharge_size median_discharge_size_this_hour];
+                           
+            if length(dph) < length(time_length_of_chunk)  
+                
+                median_discharge_size = ...
+                    [median_discharge_size median_discharge_size_this_hour];
+
+                dph = [dph avg_discharges_this_hour];
+
+                dph_std = [dph_std std_this_hour];
             
-            dph = [dph avg_discharges_this_hour];
-            
-            dph_std = [dph_std std_this_hour];
+            end
 
         % if there is less than thirty minutes of unaccounted-for discharge
         % time, just roll it into the last point and re-average that 
@@ -410,9 +527,9 @@ live_time = 0.0;
 
                 else
 
-                    [row, col, val] = find(discharge_vals(1,start_time_index:end));
+                    [row, col, vals] = find(discharge_vals(1,start_time_index:end));
 
-                    median_discharge_size_this_hour = median(val);
+                    median_discharge_size_this_hour = median(vals);
 
                 end
                 
@@ -424,42 +541,103 @@ live_time = 0.0;
 
                     else
 
-                        [row, col, val] = find([median_discharge_size(end) discharge_vals(1,start_time_index:end)]);
+                        [row, col, vals] = ...
+                            find([median_discharge_size(end) discharge_vals(1,start_time_index:end)]);
 
-                        median_discharge_size_this_hour = median(val);
+                        median_discharge_size_this_hour = median(vals);
 
                     end
                     
             end
 
             if length(dph) > 0
-
-%                 dph(end) = (dph(end) + (live_time/60.0)*avg_discharges_this_hour)/(1.0+live_time/60.0);
-% 
-%                 dph_std(end) = sqrt(dph(end));
                 
-                dph(end) = ceil((dph(end) + (live_time/60.0)*avg_discharges_this_hour)/(1.0+live_time/60.0));
+                previous_live_time = live_time_list(end);
 
-                dph_std(end) = ceil(sqrt((dph_std(end)*(live_time/60.0))^2 + ...
-                    (std_this_hour*live_time/60)^2)/(1.0+live_time/60.0));
+                dph(end) = ceil((dph(end)*previous_live_time/60. + ...
+                    (live_time/60.0)*avg_discharges_this_hour)/((previous_live_time+live_time)/60.0));
+
+                dph_std(end) = ceil(sqrt( (dph_std(end)*(previous_live_time/60.0))^2 + ...
+                    (std_this_hour*live_time/60.)^2 )/((previous_live_time+live_time)/60.0));
 
                 median_discharge_size(end) = median_discharge_size_this_hour;
                 
             else
                 
-%                 dph = [dph (live_time/60.0)*avg_discharges_this_hour/(1.0+live_time/60.0)];
-% 
-%                 dph_std = [ dph_std sqrt(dph(end))];
+                if length(dph) < length(time_length_of_chunk)  
+                    
+                    dph = [dph ceil(avg_discharges_this_hour/(live_time/60.0))];
+
+                    dph_std = [ dph_std ceil(sqrt(length(vals))/(live_time/60.0))];
+
+                    median_discharge_size = [ median_discharge_size median_discharge_size_this_hour];
                 
-                dph = [dph ceil((live_time/60.0)*avg_discharges_this_hour/(1.0+live_time/60.0))];
-
-                dph_std = [ dph_std ceil(sqrt((dph_std(end)*(live_time/60.0))^2 + ...
-                    (std_this_hour*live_time/60)^2)/(1.0+live_time/60.0))];
-
-                median_discharge_size = [ median_discharge_size median_discharge_size_this_hour];
+                end
                 
             end
-    
+            
+        end
+        
+%         live_time_list
+        
+ % plot histograms of the discharges. 
+ 
+%         dph
+%         
+%         vals_per_hour
+
+        
+
+        if save_figs == 1
+            
+            vals_index = 1;
+            
+            if length(dph) > 1
+                
+                save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,1));
+
+                if vals_per_hour(1) > 0
+                    
+                    vals_index = vals_per_hour(1)+1;
+                    
+                    plot_discharge_hist(vals_list(1:vals_per_hour(1)),...
+                                title_string,1,save_file_path,xlabel_string,ylabel_string)
+                else
+                    
+                    plot_discharge_hist([],...
+                                title_string,1,save_file_path,xlabel_string,ylabel_string)
+                    
+                end
+                        
+                for i = 2:length(dph)
+
+                    save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,i));
+                    
+                    if vals_per_hour(i) > 0
+                        
+                        plot_discharge_hist(vals_list(vals_index:vals_index+vals_per_hour(i)-1),...
+                                    title_string,i,save_file_path,xlabel_string,ylabel_string)
+
+                        vals_index = vals_per_hour(i)+1;
+                            
+                    else
+                        
+                        plot_discharge_hist([],...
+                                title_string,i,save_file_path,xlabel_string,ylabel_string)
+                        
+                    end
+
+                end
+                
+            elseif length(dph) == 1    
+                
+                save_file_path = fullfile(savepath,sprintf('%s_%d.png',plotname,hour_number));
+
+                plot_discharge_hist(vals_list,...
+                            title_string,hour_number,save_file_path,xlabel_string,ylabel_string)
+                
+            end
+                        
         end
     
     end

--- a/cumulative_discharge_rate_plotter.m
+++ b/cumulative_discharge_rate_plotter.m
@@ -2,9 +2,9 @@
 
 % electrodes = 'Nb56';
 % electrodes = 'Ti13';
-% electrodes = 'Nb78';
+electrodes = 'Nb78';
 % electrodes = 'Nb23';
-electrodes = 'NET';
+% electrodes = 'NET';
 
 % sim_dates = '12/13/2018--5/1/2019';
 
@@ -20,7 +20,8 @@ file_polarity_name = {'pos','neg','zero'};
 % analysis_folder_name_parent = '2019-07-11-all-ti13-sim-analysis-files';
 % analysis_folder_name_parent = '2019-07-11-nb78-all-simulation-analysis';
 % analysis_folder_name_parent = '2020-03-12-nb23-analysis-files';
-analysis_folder_name_parent = '2020-06-17-NET-analysis-files';
+% analysis_folder_name_parent = '2020-06-17-NET-analysis-files';
+analysis_folder_name_parent = '2020-06-24-nb78-all-analysis-again';
 
 % analysis_folder_name = '2019-07-11'; % latest nb56 analysis
 analysis_folder_name = ''; % latest ti13 analysis
@@ -56,13 +57,9 @@ mkdir(fullpath);
 %     discharge_size_cutoff_bounds = [-5 120 -50 2000];
     
 % Nb78 bounds
-%     discharge_rate_sigma_bounds = [0 31 -0.25 10];
-%     
-%     discharge_size_sigma_bounds = [0 31 -0.5 14];
-%     
-%     discharge_rate_cutoff_bounds = [0 31 -1 1];
-%     
-%     discharge_size_cutoff_bounds = [0 31 -1 1];  
+    discharge_rate_bounds = [0 31 -500 3000];
+    
+    discharge_size_bounds = [0 31 -50 450];
     
 % Nb23 bounds
 %     discharge_rate_bounds = [-5 140 -100 3000];
@@ -70,20 +67,14 @@ mkdir(fullpath);
 %     discharge_size_bounds = [-5 140 -50 1600];
     
 % NET bounds
-    discharge_rate_bounds = [0 30 -200 7000];
-    
-    discharge_size_bounds = [0 30 -100 2500];
+%     discharge_rate_bounds = [0 30 -200 7000];
+%     
+%     discharge_size_bounds = [0 30 -100 2500];
 
     
     
     
-%     yname_rate = 'discharge rate - baseline (hr^{-1})';
-%     
-%     yname_size = 'median discharge size - baseline (pA)';
-    
-    yname_rate = 'discharge rate (hr^{-1})';
-    
-    yname_size = 'median discharge size (pA)';
+
     
     
 % for i = 1:length(analysis_file_patterns)
@@ -152,21 +143,33 @@ for i = 1:2
     median_sigma = zeros(number_rows,1);
     median_cutoff = zeros(number_rows,1);
 
-%     dph_sigma_baseline = mean(one_big_data_set(1:number_rows_first_set,3));
-%     
-%     dph_cutoff_baseline = mean(one_big_data_set(1:number_rows_first_set,6));
-% 
-%     size_sigma_baseline = mean(one_big_data_set(1:number_rows_first_set,5));
-%     
-%     size_cutoff_baseline = mean(one_big_data_set(1:number_rows_first_set,8));
+    dph_sigma_baseline = mean(one_big_data_set(1:number_rows_first_set,3));
     
-    dph_sigma_baseline = 0.0;
-    
-    dph_cutoff_baseline = 0.0;
+    dph_cutoff_baseline = mean(one_big_data_set(1:number_rows_first_set,6));
 
-    size_sigma_baseline = 0.0;
+    size_sigma_baseline = mean(one_big_data_set(1:number_rows_first_set,5));
     
-    size_cutoff_baseline = 0.0;
+    size_cutoff_baseline = mean(one_big_data_set(1:number_rows_first_set,8));
+    
+%     dph_sigma_baseline = 0.0;
+%     
+%     dph_cutoff_baseline = 0.0;
+% 
+%     size_sigma_baseline = 0.0;
+%     
+%     size_cutoff_baseline = 0.0;
+
+    %     yname_rate = 'discharge rate - baseline (hr^{-1})';
+%     
+%     yname_size = 'median discharge size - baseline (pA)';
+    
+    yname_rate_sigma = sprintf('discharge rate - %.0f  (hr^{-1})',dph_sigma_baseline);
+    
+    yname_rate_cutoff = sprintf('discharge rate - %.0f  (hr^{-1})',dph_cutoff_baseline);
+    
+    yname_size_sigma = sprintf('median discharge size - %.0f  (pA)',size_sigma_baseline);
+    
+    yname_size_cutoff = sprintf('median discharge size - %.0f  (pA)',size_cutoff_baseline);
 
     for j = 1:number_rows
 
@@ -212,25 +215,25 @@ for i = 1:2
 %         discharge_size_bounds,1:number_rows,zeros(length(1:number_rows),1),...
 %         median_cutoff,zeros(length(median_cutoff),1),this_set_indices);
 
-    hv_plot_xy_errors(pname_sig_rate,'conditioning time (hr)',yname_rate,...
+    hv_plot_xy_errors(pname_sig_rate,'conditioning time (hr)',yname_rate_sigma,...
         2,'',1,2,2,fullpath,...
         sprintf('%s-discharge-rates-sigma-%s',electrodes,string(file_polarity_name(i))),...
         discharge_rate_bounds,linspace(1,number_rows,number_rows),...
         linspace(0,0,number_rows),dph_sigma(:,1),dph_sigma(:,2),this_set_indices);
     
-    hv_plot_xy_errors(pname_sig_size,'conditioning time (hr)',yname_size,...
+    hv_plot_xy_errors(pname_sig_size,'conditioning time (hr)',yname_size_sigma,...
         2,'',1,2,2,fullpath,sprintf('%s-median-discharges-sigma-%s',electrodes,...
         string(file_polarity_name(i))),...
         discharge_size_bounds,linspace(1,number_rows,number_rows),linspace(0,0,number_rows),...
         median_sigma,zeros(length(median_sigma),1),this_set_indices);
     
-    hv_plot_xy_errors(pname_cut_rate,'conditioning time (hr)',yname_rate,...
+    hv_plot_xy_errors(pname_cut_rate,'conditioning time (hr)',yname_rate_cutoff,...
         2,'',1,2,2,fullpath,sprintf('%s-discharge-rates-cutoff-%s',electrodes,...
         string(file_polarity_name(i))),...
         discharge_rate_bounds,linspace(1,number_rows,number_rows),linspace(0,0,number_rows),...
         dph_cutoff(:,1),dph_cutoff(:,2),this_set_indices);
     
-    hv_plot_xy_errors(pname_cut_size,'conditioning time (hr)',yname_size,...
+    hv_plot_xy_errors(pname_cut_size,'conditioning time (hr)',yname_size_cutoff,...
         2,'',1,2,2,fullpath,sprintf('%s-median-discharges-cutoff-%s',electrodes,...
         string(file_polarity_name(i))),...
         discharge_size_bounds,linspace(1,number_rows,number_rows),linspace(0,0,number_rows),...

--- a/hv_plot_xy_errors.m
+++ b/hv_plot_xy_errors.m
@@ -202,8 +202,10 @@ matter)can be ignored by setting x_data-stdev_i to an array of zeros.
 
 %         legend_names = {'12 kV','13.0 kV','14.0 kV','14.0 kV','15 kV',...
 %             '16 kV','17.0 kV','17.0 kV','17.0 kV','17.5 kV','18.0 kV'};
-%         
-%         color_code_by_voltage = [1 2 3 3 4 5 6 6 6 7 8];
+        
+        voltages = [12.0 12.9 13.9 13.9 14.9 15.9 17.0 16.9 17.0 17.5 17.9];
+        
+        color_code_by_voltage = [1 2 3 3 4 5 7 6 7 8 9];
         
 % Nb23 legend entries and color code
         
@@ -216,9 +218,11 @@ matter)can be ignored by setting x_data-stdev_i to an array of zeros.
 %         color_code_by_voltage = [1 2 2 2 3 3 3 4 4 4 5 5 5 5 5 6 6 6 6 6 6 7 7 7 7 7 7 7];
         
 % NET legend entries and color code        
-        voltages = [14.7 22.2 26.2 23.4 10.4 12.4 6.1 3.2 9.0];
+%         voltages = [14.7 22.2 26.2 23.4 10.4 12.4 6.1 3.2 9.0];
+%         
+%         color_code_by_voltage = [6 7 9 8 4 5 2 1 3];
         
-        color_code_by_voltage = [6 7 9 8 4 5 2 1 3];
+        
         
         xrange = max(xdata_1) - min(xdata_1);
         yrange = max(ydata_1) - min(ydata_1);
@@ -494,10 +498,28 @@ matter)can be ignored by setting x_data-stdev_i to an array of zeros.
 
             colorbar_ticklabel_string = cell(1,color_code_by_voltage(end));
             
-            ordered_voltages = sort(voltages);
+            unique_voltages = [];
+            
+            for i =1:length(voltages)
+                
+                duplicates = (unique_voltages == voltages(i));
+                
+                if sum(duplicates) == 0
+                
+                    unique_voltages(end+1) = voltages(i);
+                    
+                end
+                    
+            end
+            
+            
+            ordered_voltages = sort(unique_voltages);
+            
+            
 
             for i = 1:max(color_code_by_voltage)
-
+                
+                
                 colorbar_ticklabel_string{i} = sprintf('%.1f kV',ordered_voltages(i));
 
             end


### PR DESCRIPTION
…e plots which traced back to calc_discharge_rate not computing discharge rates correctly. The last time I did this analysis, Nb78 had almost zero discharges. This issue came up because of a syntax error that was not thrown by MATLAB, thus escaping notice. A misnamed variable was treated as zero instead of undefined. Now that's corrected and we see a much more reasonable discharge rate plot for Nb78. Made a batch processing script for Nb78.